### PR TITLE
Correctly prioritize filenames without keywords

### DIFF
--- a/coverparse/coverparse.go
+++ b/coverparse/coverparse.go
@@ -67,6 +67,9 @@ func init() {
 
 func posArtTypes(path string) []int {
 	matches := artTypeExpr.FindAllString(path, -1)
+	if len(matches) == 0 {
+		return []int{1} // a score of 1 is worse than any priority (which are <= 0)
+	}
 	r := make([]int, len(matches))
 	for i, m := range matches {
 		r[i] = -artTypePriorities[m]

--- a/coverparse/coverparse_test.go
+++ b/coverparse/coverparse_test.go
@@ -62,6 +62,11 @@ func TestSelection(t *testing.T) {
 			expected: "cover_special.jpg",
 		},
 		{
+			name:     "folder vs CD",
+			covers:   []string{"CD.jpg", "folder.jpg"},
+			expected: "folder.jpg",
+		},
+		{
 			name: "cds",
 			covers: []string{
 				"cd 2/cover art file A10 01.png",


### PR DESCRIPTION
Previously, the cover art sorting logic would incorrectly prioritize filenames with no recognized keywords (e.g., `CD.jpg`) over filenames with a low-priority keyword (e.g., `folder.jpg`).

This was caused by the `posArtTypes` function returning an empty slice for files with no keywords, which the `Compare` function's logic did not handle correctly.

This commit refactors the `posArtTypes` function to return a default low-priority score when no keywords are found. This ensures that any file with a recognized keyword is always ranked higher than one without, fixing the bug and simplifying the main `Compare` function.

A test case has been added to verify the fix