### PR TITLE
Safepath function without unicode normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,21 +442,22 @@ The template has access to the following data:
 
 In addition to what's provided by Go [text/template](https://pkg.go.dev/text/template), several helper functions are available to format your paths:
 
-| Function              | Description                                                | Example                                                      |
-| --------------------- | ---------------------------------------------------------- | ------------------------------------------------------------ |
-| `join`                | Joins strings with a delimiter                             | `{{ artists .Release.Artists \| join "; " }}`                |
-| `pad0`                | Zero-pads a number to specified width                      | `{{ pad0 2 .TrackNum }}` → "01"                              |
-| `sort`                | Sorts a string array                                       | `{{ artists .Release.Artists \| sort }}`                     |
-| `the`                 | Moves `A` and `The` to the end of each string in the input | `{{ artists .Release.Artists \| sort \| the \| join "; " }}` |
-| `safepath`            | Makes a string safe for filesystem use                     | `{{ .Track.Title \| safepath }}`                             |
-| `artists`             | Gets artist names from artist credits                      | `{{ artists .Release.Artists }}`                             |
-| `artistsString`       | Formats artists as a string                                | `{{ artistsString .Track.Artists }}`                         |
-| `artistsEn`           | Gets artist names in English locale from artist credits    | `{{ artistsEn .Release.Artists }}`                           |
-| `artistsEnString`     | Formats artists names in English locale as a string        | `{{ artistsEnString .Track.Artists }}`                       |
-| `artistsCredit`       | Gets credit names from artist credits                      | `{{ artistsCredit .Release.Artists }}`                       |
-| `artistsCreditString` | Formats artist credits as a string                         | `{{ artistsCreditString .Release.Artists }}`                 |
-| `artistsSort`         | Gets sort names from artist credits                        | `{{ artistsSort .Release.Artists \| sort \| join "; " }}`    |
-| `artistsSortString`   | Formats artist sort names as a credits                     | `{{ artistsSortString .Release.Artists }}`                   |
+| Function              | Description                                                        | Example                                                      |
+| --------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------ |
+| `join`                | Joins strings with a delimiter                                     | `{{ artists .Release.Artists \| join "; " }}`                |
+| `pad0`                | Zero-pads a number to specified width                              | `{{ pad0 2 .TrackNum }}` → "01"                              |
+| `sort`                | Sorts a string array                                               | `{{ artists .Release.Artists \| sort }}`                     |
+| `the`                 | Moves `A` and `The` to the end of each string in the input         | `{{ artists .Release.Artists \| sort \| the \| join "; " }}` |
+| `safepath`            | Makes a string safe for filesystem use                             | `{{ .Track.Title \| safepath }}`                             |
+| `safepathUnicode`     | Removes illegal characters from filenames while preserving Unicode | `{{ .Track.Title \| safepathUnicode}}`                       |
+| `artists`             | Gets artist names from artist credits                              | `{{ artists .Release.Artists }}`                             |
+| `artistsString`       | Formats artists as a string                                        | `{{ artistsString .Track.Artists }}`                         |
+| `artistsEn`           | Gets artist names in English locale from artist credits            | `{{ artistsEn .Release.Artists }}`                           |
+| `artistsEnString`     | Formats artists names in English locale as a string                | `{{ artistsEnString .Track.Artists }}`                       |
+| `artistsCredit`       | Gets credit names from artist credits                              | `{{ artistsCredit .Release.Artists }}`                       |
+| `artistsCreditString` | Formats artist credits as a string                                 | `{{ artistsCreditString .Release.Artists }}`                 |
+| `artistsSort`         | Gets sort names from artist credits                                | `{{ artistsSort .Release.Artists \| sort \| join "; " }}`    |
+| `artistsSortString`   | Formats artist sort names as a credits                             | `{{ artistsSortString .Release.Artists }}`                   |
 
 ## Example formats
 

--- a/fileutil/fileutil.go
+++ b/fileutil/fileutil.go
@@ -58,6 +58,7 @@ func SafePath(path string) string {
 func SafePathUnicode(path string) string {
 	path = safePathReplacer.Replace(path)
 	path = strings.Join(strings.Fields(path), " ")
+	path = cmp.Or(path, "_")
 	return path
 }
 

--- a/fileutil/fileutil.go
+++ b/fileutil/fileutil.go
@@ -55,6 +55,12 @@ func SafePath(path string) string {
 	return path
 }
 
+func SafePathUnicode(path string) string {
+	path = safePathReplacer.Replace(path)
+	path = strings.Join(strings.Fields(path), " ")
+	return path
+}
+
 // normUnidecode tries to be compatible with beets.io's version, though there are some slight differences.
 // see https://github.com/beetbox/beets/blob/master/beets/library.py
 //   - unicodedata.normalize('NFC', path) (from https://docs.python.org/3/library/unicodedata.html)

--- a/fileutil/fileutil_test.go
+++ b/fileutil/fileutil_test.go
@@ -25,6 +25,21 @@ func TestSafePath(t *testing.T) {
 	assert.Equal(t, "(2007)", fileutil.SafePath("(2007) ✝")) // need to fix this
 }
 
+func TestSafePathUnicode(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "hello", fileutil.SafePathUnicode("hello"))
+	assert.Equal(t, "hello", fileutil.SafePathUnicode("hello/"))
+	assert.Equal(t, "hello a", fileutil.SafePathUnicode("hello/a"))
+	assert.Equal(t, "hello a", fileutil.SafePathUnicode("hello / a"))
+	assert.Equal(t, "hello", fileutil.SafePathUnicode("hel\x00lo"))
+	assert.Equal(t, "a b", fileutil.SafePathUnicode("a  b"))
+	assert.Equal(t, "(2004) Kesto (234.484)", fileutil.SafePathUnicode("(2004) Kesto (234.48:4)"))
+	assert.Equal(t, "01.33 Rähinä I Mayhem I", fileutil.SafePathUnicode("01.33 Rähinä I Mayhem I"))
+	assert.Equal(t, "50 ¢.flac", fileutil.SafePathUnicode("50 ¢.flac"))
+	assert.Equal(t, "(2007) ✝", fileutil.SafePathUnicode("(2007) ✝"))
+}
+
 func TestWalkLeaves(t *testing.T) {
 	t.Parallel()
 

--- a/fileutil/fileutil_test.go
+++ b/fileutil/fileutil_test.go
@@ -38,6 +38,7 @@ func TestSafePathUnicode(t *testing.T) {
 	assert.Equal(t, "01.33 Rähinä I Mayhem I", fileutil.SafePathUnicode("01.33 Rähinä I Mayhem I"))
 	assert.Equal(t, "50 ¢.flac", fileutil.SafePathUnicode("50 ¢.flac"))
 	assert.Equal(t, "(2007) ✝", fileutil.SafePathUnicode("(2007) ✝"))
+	assert.Equal(t, "_", fileutil.SafePathUnicode(">///<"))
 }
 
 func TestWalkLeaves(t *testing.T) {

--- a/pathformat/pathformat.go
+++ b/pathformat/pathformat.go
@@ -191,10 +191,11 @@ func validate(f Format) error {
 }
 
 var funcMap = texttemplate.FuncMap{
-	"join":     func(delim string, items []string) string { return strings.Join(items, delim) },
-	"pad0":     func(amount, n int) string { return fmt.Sprintf("%0*d", amount, n) },
-	"sort":     func(strs []string) []string { sort.Strings(strs); return strs },
-	"safepath": func(p string) string { return fileutil.SafePath(p) },
+	"join":            func(delim string, items []string) string { return strings.Join(items, delim) },
+	"pad0":            func(amount, n int) string { return fmt.Sprintf("%0*d", amount, n) },
+	"sort":            func(strs []string) []string { sort.Strings(strs); return strs },
+	"safepath":        func(p string) string { return fileutil.SafePath(p) },
+	"safepathUnicode": func(p string) string { return fileutil.SafePathUnicode(p) },
 
 	"artists":             musicbrainz.ArtistsNames,
 	"artistsString":       musicbrainz.ArtistsString,


### PR DESCRIPTION
This PR adds the template function `safepathUnicode`. The function works similarly to `safepath`, but leaves Unicode characters unchanged, so, for example, Cyrillic names are not transliterated.