### PR TITLE
Include essentia extractor binary in container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,13 @@ RUN  \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /out/ ./cmd/...
 
 FROM alpine:3.22 AS essentia-extractors
+ARG VERSION="v2.1_beta2"
 ARG TARGETARCH
+WORKDIR /tmp
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
-      apk add --no-cache curl tar \
-      && curl -L -o essentia-extractors.tar.gz https://essentia.upf.edu/extractors/essentia-extractors-v2.1_beta2-linux-x86_64.tar.gz \
-      && tar -xzvf essentia-extractors.tar.gz; \
+    apk add --no-cache curl tar; \
+    curl -fL -o essentia-extractors.tar.gz https://essentia.upf.edu/extractors/essentia-extractors-${VERSION}-linux-x86_64.tar.gz; \
+    tar -xzf essentia-extractors.tar.gz --strip-components=1 -- essentia-extractors-${VERSION}/streaming_extractor_music; \
     fi
 
 FROM alpine:3.22
@@ -26,7 +28,7 @@ RUN apk add -U --no-cache \
     su-exec \
     rsgain
 COPY --from=builder /out/* /usr/local/bin/
-COPY --from=essentia-extractors /tmp/streaming_extractor_music /usr/local/bin/
+COPY --from=essentia-extractors /tmp/streaming_extractor_music* /usr/local/bin/
 COPY docker-entry /
 ENTRYPOINT ["/docker-entry"]
 CMD ["wrtagweb"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     fi
 
 FROM alpine:3.22
-ARG TARGETARCH
 LABEL org.opencontainers.image.source=https://github.com/sentriz/wrtag
 RUN apk add -U --no-cache \
     su-exec \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN  \
 
 FROM alpine:3.22 AS essentia-extractors
 ARG TARGETARCH
-RUN if [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "x86_64" ]; then \
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
       apk add --no-cache curl tar \
       && curl -L -o essentia-extractors.tar.gz https://essentia.upf.edu/extractors/essentia-extractors-v2.1_beta2-linux-x86_64.tar.gz \
       && tar -xzvf essentia-extractors.tar.gz; \


### PR DESCRIPTION
Essentia provides binaries for x86_64 Linux and i686. The 32 bit binaries are not included as it is unlikely that they will be used. The `essentia-extractors` stage will only execute for 64 bit image builds.

Closes #161