### PR TITLE
fix(musicbrainz): filter Blu-ray media in FlatTracks

### DIFF
--- a/musicbrainz/musicbrainz.go
+++ b/musicbrainz/musicbrainz.go
@@ -461,7 +461,7 @@ func IsCompilation(rg ReleaseGroup) bool {
 func FlatTracks(media []Media) []Track {
 	var tracks []Track
 	for _, media := range media {
-		if strings.Contains(media.Format, "DVD") {
+		if strings.Contains(media.Format, "DVD") || strings.Contains(media.Format, "Blu-ray") {
 			// not supported for now
 			continue
 		}

--- a/musicbrainz/musicbrainz_test.go
+++ b/musicbrainz/musicbrainz_test.go
@@ -38,3 +38,88 @@ func TestMergeAndSortGenres(t *testing.T) {
 		}),
 	)
 }
+
+func TestFlatTracks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("filters DVD media", func(t *testing.T) {
+		t.Parallel()
+		media := []Media{
+			{Format: "DVD", Tracks: []Track{{ID: "dvd-track"}}},
+			{Format: "CD", Tracks: []Track{{ID: "cd-track"}}},
+		}
+		tracks := FlatTracks(media)
+		assert.Len(t, tracks, 1)
+		assert.Equal(t, "cd-track", tracks[0].ID)
+	})
+
+	t.Run("filters Blu-ray media", func(t *testing.T) {
+		t.Parallel()
+		media := []Media{
+			{Format: "Blu-ray", Tracks: []Track{{ID: "bluray-track"}}},
+			{Format: "CD", Tracks: []Track{{ID: "cd-track"}}},
+		}
+		tracks := FlatTracks(media)
+		assert.Len(t, tracks, 1)
+		assert.Equal(t, "cd-track", tracks[0].ID)
+	})
+
+	t.Run("includes CD media", func(t *testing.T) {
+		t.Parallel()
+		media := []Media{
+			{Format: "CD", Tracks: []Track{{ID: "cd-track-1"}}},
+			{Format: "CD", Tracks: []Track{{ID: "cd-track-2"}}},
+		}
+		tracks := FlatTracks(media)
+		assert.Len(t, tracks, 2)
+		assert.Equal(t, "cd-track-1", tracks[0].ID)
+		assert.Equal(t, "cd-track-2", tracks[1].ID)
+	})
+
+	t.Run("filters video tracks", func(t *testing.T) {
+		t.Parallel()
+		media := []Media{
+			{Format: "CD", Tracks: []Track{
+				{ID: "audio-track", Recording: struct {
+					FirstReleaseDate string         `json:"first-release-date"`
+					Genres           []Genre        `json:"genres"`
+					Video            bool           `json:"video"`
+					Disambiguation   string         `json:"disambiguation"`
+					ID               string         `json:"id"`
+					Length           int            `json:"length"`
+					Title            string         `json:"title"`
+					Artists          []ArtistCredit `json:"artist-credit"`
+					Relations        []Relation     `json:"relations"`
+					ISRCs            []string       `json:"isrcs"`
+				}{Video: false}},
+				{ID: "video-track", Recording: struct {
+					FirstReleaseDate string         `json:"first-release-date"`
+					Genres           []Genre        `json:"genres"`
+					Video            bool           `json:"video"`
+					Disambiguation   string         `json:"disambiguation"`
+					ID               string         `json:"id"`
+					Length           int            `json:"length"`
+					Title            string         `json:"title"`
+					Artists          []ArtistCredit `json:"artist-credit"`
+					Relations        []Relation     `json:"relations"`
+					ISRCs            []string       `json:"isrcs"`
+				}{Video: true}},
+			}},
+		}
+		tracks := FlatTracks(media)
+		assert.Len(t, tracks, 1)
+		assert.Equal(t, "audio-track", tracks[0].ID)
+	})
+
+	t.Run("includes pregap track", func(t *testing.T) {
+		t.Parallel()
+		pregapTrack := Track{ID: "pregap-track"}
+		media := []Media{
+			{Format: "CD", Pregap: &pregapTrack, Tracks: []Track{{ID: "regular-track"}}},
+		}
+		tracks := FlatTracks(media)
+		assert.Len(t, tracks, 2)
+		assert.Equal(t, "pregap-track", tracks[0].ID)
+		assert.Equal(t, "regular-track", tracks[1].ID)
+	})
+}


### PR DESCRIPTION
The FlatTracks function was only filtering DVD media formats,
which caused issues with releases containing Blu-ray discs. When processing such releases, the
Blu-ray tracks would be included alongside the audio CD tracks, resulting in a track count mismatch that prevented successful tagging.