### PR TITLE
fix(musicbrainz): artistEnName picks primary alias first, rejects ended aliases

### DIFF
--- a/musicbrainz/musicbrainz.go
+++ b/musicbrainz/musicbrainz.go
@@ -435,7 +435,12 @@ const enLocale = "en"
 
 func artistEnName(artist Artist) string {
 	for _, a := range artist.Aliases {
-		if a.Locale == enLocale {
+		if a.Locale == enLocale && a.Primary && !a.Ended {
+			return a.Name
+		}
+	}
+	for _, a := range artist.Aliases {
+		if a.Locale == enLocale && !a.Ended {
 			return a.Name
 		}
 	}

--- a/musicbrainz/musicbrainz_test.go
+++ b/musicbrainz/musicbrainz_test.go
@@ -123,3 +123,76 @@ func TestFlatTracks(t *testing.T) {
 		assert.Equal(t, "regular-track", tracks[1].ID)
 	})
 }
+
+func TestArtistEnName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns primary non-ended English alias", func(t *testing.T) {
+		t.Parallel()
+		artist := Artist{
+			Name: "跡部進一",
+			Aliases: []Alias{
+				{Name: "Shinichi Atobe", Locale: "en", Primary: true, Ended: false},
+				{Name: "Other English Name", Locale: "en", Primary: false, Ended: false},
+			},
+		}
+		assert.Equal(t, "Shinichi Atobe", artistEnName(artist))
+	})
+
+	t.Run("returns non-primary non-ended English alias when no primary exists", func(t *testing.T) {
+		t.Parallel()
+		artist := Artist{
+			Name: "Native Name",
+			Aliases: []Alias{
+				{Name: "English Name", Locale: "en", Primary: false, Ended: false},
+			},
+		}
+		assert.Equal(t, "English Name", artistEnName(artist))
+	})
+
+	t.Run("skips ended English aliases", func(t *testing.T) {
+		t.Parallel()
+		artist := Artist{
+			Name: "Taylor Swift",
+			Aliases: []Alias{
+				{Name: "Dr. Taylor Alison Swift", Locale: "en", Primary: false, Ended: true},
+				{Name: "Taylor Swift", Locale: "en", Primary: true, Ended: false},
+			},
+		}
+		assert.Equal(t, "Taylor Swift", artistEnName(artist))
+	})
+
+	t.Run("returns artist name when only ended English aliases exist", func(t *testing.T) {
+		t.Parallel()
+		artist := Artist{
+			Name: "Artist Name",
+			Aliases: []Alias{
+				{Name: "Old English Name", Locale: "en", Primary: true, Ended: true},
+			},
+		}
+		assert.Equal(t, "Artist Name", artistEnName(artist))
+	})
+
+	t.Run("returns artist name when no English aliases exist", func(t *testing.T) {
+		t.Parallel()
+		artist := Artist{
+			Name: "Artist Name",
+			Aliases: []Alias{
+				{Name: "日本語名", Locale: "ja", Primary: true, Ended: false},
+			},
+		}
+		assert.Equal(t, "Artist Name", artistEnName(artist))
+	})
+
+	t.Run("prioritizes primary over non-primary even if non-primary appears first", func(t *testing.T) {
+		t.Parallel()
+		artist := Artist{
+			Name: "Native Name",
+			Aliases: []Alias{
+				{Name: "Non-Primary English", Locale: "en", Primary: false, Ended: false},
+				{Name: "Primary English", Locale: "en", Primary: true, Ended: false},
+			},
+		}
+		assert.Equal(t, "Primary English", artistEnName(artist))
+	})
+}


### PR DESCRIPTION
This PR modifies artistEnName to respect the primary and ended fields on aliases. The current behavior will simply pick the first English alias it finds, ignoring the designated primary alias.

For example, when importing an album by Taylor Swift, artistEnName resolves to "Dr. Taylor Alison Swift", despite this not being the primary alias (Taylor Swift). [Aliases page](https://musicbrainz.org/artist/20244d07-534f-4eff-b4d4-930878889970/aliases)

Additionally, artists can have aliases marked as "ended", which should be respected when fetching their name.