### PR TITLE
Do not run chown in docker-entry

### DIFF
--- a/docker-entry
+++ b/docker-entry
@@ -10,7 +10,4 @@ USERNAME=wrtag
 
 adduser -D -u "$PUID" -g "$PGID" "$USERNAME" 2>/dev/null || true
 
-[ -d "/data" ] && chown -R "$PUID:$PGID" /data
-[ -d "/config" ] && chown -R "$PUID:$PGID" /config
-
 exec su-exec "$PUID:$PGID" "$@"

--- a/docker-entry
+++ b/docker-entry
@@ -10,4 +10,7 @@ USERNAME=wrtag
 
 adduser -D -u "$PUID" -g "$PGID" "$USERNAME" 2>/dev/null || true
 
+[ -n "$WRTAG_WEB_DB_PATH" ] && mkdir -p "$(dirname "$WRTAG_WEB_DB_PATH")" && chown "$PUID:$PGID" "$(dirname "$WRTAG_WEB_DB_PATH")"
+[ -n "$WRTAG_CONFIG_PATH" ] && chown "$PUID:$PGID" "$(dirname "$WRTAG_CONFIG_PATH")"
+
 exec su-exec "$PUID:$PGID" "$@"


### PR DESCRIPTION
The reasons are as follows:
- The `/data` and `/config` directories are only example directories, but both the music and the db can be stored wherever based on the `WRTAG_WEB_DB_PATH` and the template so these could be completely unrelated
- There is no need for these directories to be owned by the user, they can be world-editable or group-editable, I don't think changing the owner should be the job of the docker image
- Both the db and music can be nested somewhere below these dirs, possible chowning a big chunk of the system unknowingly (Someone could have `/config:/var` mount and set `WRTAG_WEB_DB_PATH=/config/wrtag/wrtag.db`).
- In my case this caused a very slow startup, since my `/data` directory is a cloud mount with a lot of files so the chowning could easily take 30 mins.