### PR TITLE
Skip check if on darwin

### DIFF
--- a/cmd/wrtag/testdata/scripts/cover-extension-lowercase.txtar
+++ b/cmd/wrtag/testdata/scripts/cover-extension-lowercase.txtar
@@ -18,7 +18,7 @@ exec wrtag move -yes kat_moda/
 exec find albums/
 cmp stdout exp-layout
 
-! exists 'albums/Kat Moda/cover.PNG'
+[!darwin] ! exists 'albums/Kat Moda/cover.PNG'
 exists 'albums/Kat Moda/cover.png'
 
 -- exp-layout --


### PR DESCRIPTION
Hey, found out that when running `go test` on MacOS, the **cover-extension-lowercase** fails because MacOS considers `cover.png` and `cover.PNG` to be the same file.

This change makes all tests pass on MacOS as it skips that specific check. 