### PR TITLE
feat(wrtag): add cover-group config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ Global configuration is used by all tools. Any option can be provided with a CLI
 | -caa-rate-limit   | WRTAG_CAA_RATE_LIMIT   | caa-rate-limit   | CoverArtArchive rate limit duration                                                                  |
 | -config           | WRTAG_CONFIG           | config           | Print the parsed config and exit                                                                     |
 | -config-path      | WRTAG_CONFIG_PATH      | config-path      | Path to config file (default "$XDG_CONFIG_HOME/wrtag/config")                                        |
+| -cover-group      | WRTAG_COVER_GROUP      | cover-group      | Fetch cover art from the MusicBrainz release group only, rather than the specific release too        |
 | -cover-upgrade    | WRTAG_COVER_UPGRADE    | cover-upgrade    | Fetch new cover art even if it exists locally                                                        |
 | -diff-weight      | WRTAG_DIFF_WEIGHT      | diff-weight      | Adjust distance weighting for a tag (0 to ignore) (stackable)                                        |
 | -keep-file        | WRTAG_KEEP_FILE        | keep-file        | Define an extra file path to keep when moving/copying to root dir (stackable)                        |

--- a/cmd/internal/wrtagflag/wrtagflag.go
+++ b/cmd/internal/wrtagflag/wrtagflag.go
@@ -95,6 +95,8 @@ func Config() *wrtag.Config {
 
 	cfg.CoverArtArchiveClient.HTTPClient = &http.Client{Timeout: 30 * time.Second}
 
+	flag.BoolVar(&cfg.GroupCover, "cover-group", false, "Fetch cover art from the MusicBrainz release group only, rather than the specific release too")
+
 	flag.BoolVar(&cfg.UpgradeCover, "cover-upgrade", false, "Fetch new cover art even if it exists locally")
 
 	cfg.FileMode = defaultFileMode

--- a/contrib/completions/wrtag.bash
+++ b/contrib/completions/wrtag.bash
@@ -21,6 +21,7 @@ function _wrtag_completion() {
         --caa-rate-limit
         --config
         --config-path
+        --cover-group
         --cover-upgrade
         --diff-weight
         --keep-file
@@ -42,6 +43,7 @@ function _wrtag_completion() {
         -caa-rate-limit
         -config
         -config-path
+        -cover-group
         -cover-upgrade
         -diff-weight
         -keep-file

--- a/contrib/completions/wrtag.fish
+++ b/contrib/completions/wrtag.fish
@@ -42,6 +42,9 @@ __complete_prefer_oldstyle -c wrtag -n "not __fish_seen_subcommand_from $command
     -o config-path -rF -d 'Path to config file (default "/$HOME/.config/wrtag/config")'
 
 __complete_prefer_oldstyle -c wrtag -n "not __fish_seen_subcommand_from $commands" \
+    -o cover-group -d "Fetch cover art from the MusicBrainz release group only, rather than the specific release too"
+
+__complete_prefer_oldstyle -c wrtag -n "not __fish_seen_subcommand_from $commands" \
     -o cover-upgrade -d "Fetch new cover art even if it exists locally"
 
 __complete_prefer_oldstyle -c wrtag -n "not __fish_seen_subcommand_from $commands" \

--- a/wrtag.go
+++ b/wrtag.go
@@ -88,6 +88,7 @@ type Config struct {
 	TagConfig             TagConfig
 	KeepFiles             map[string]struct{}
 	Addons                []addon.Addon
+	GroupCover            bool
 	UpgradeCover          bool
 	FileMode              os.FileMode
 }
@@ -220,6 +221,10 @@ func ProcessDir(
 
 	var coverTmp string
 	if op.CanModifyDest() && (cover == "" || cfg.UpgradeCover) {
+		if cfg.GroupCover {
+			release.CoverArtArchive.Front = false
+		}
+
 		var err error
 		coverTmp, err = maybeFetchUpgradedCover(ctx, &cfg.CoverArtArchiveClient, release, cover, maxCoverSizeBytes)
 		if err != nil {


### PR DESCRIPTION
With many other music taggers that use MusicBrainz and the Cover Art Archive, like Picard and beets, one has the option to choose between fetching an album's cover art from either its release, or its release group. MusicBrainz's documentation also says that [*"for users that just want the 'best' canonical image for a release, without taking into account the differences between specific editions of a release, MusicBrainz provides a release group image for this purpose"*](https://musicbrainz.org/doc/Cover_Art#:~:text=For%20users,purpose%2E). This is particularly helpful for example, if an album gets automatically tagged with a release that's a non-standard edition, from a different region, has a non-square aspect ratio, is a bad scan or photo, or has a low resolution. The release group cover art on the other hand is typically far better in my experience, and if not, edits can be made to the MusicBrainz database quite easily.

This PR just adds an option to skip potentially downloading cover arts from the specific release, leaving the release group's cover art to be downloaded only. I'm not very used to reading and writing Go, though the codebase seemed very readable, and I tried my best to incorporate the changes in a similar manner to the surrounding code.

Also, thanks for this software! It's great so far, especially with how complex and involved other tools have been in my experience.