### PR TITLE
feat(wrtag): add cover-max-size config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,26 +424,27 @@ Global configuration is used by all tools. Any option can be provided with a CLI
 
 <!-- gen with ```go run ./cmd/wrtag -h 2>&1 | ./gen-docs | wl-copy``` -->
 
-| CLI argument      | Environment variable   | Config file key  | Description                                                                                          |
-| ----------------- | ---------------------- | ---------------- | ---------------------------------------------------------------------------------------------------- |
-| -addon            | WRTAG_ADDON            | addon            | Define an addon for extra metadata writing (see [Addons](#addons)) (stackable)                       |
-| -caa-base-url     | WRTAG_CAA_BASE_URL     | caa-base-url     | CoverArtArchive base URL (default "<https://coverartarchive.org/>")                                  |
-| -caa-rate-limit   | WRTAG_CAA_RATE_LIMIT   | caa-rate-limit   | CoverArtArchive rate limit duration                                                                  |
-| -config           | WRTAG_CONFIG           | config           | Print the parsed config and exit                                                                     |
-| -config-path      | WRTAG_CONFIG_PATH      | config-path      | Path to config file (default "$XDG_CONFIG_HOME/wrtag/config")                                        |
-| -cover-max-size   | WRTAG_COVER_MAX_SIZE   | cover-max-size   | Maximum size in B, KiB, MiB, or GiB for fetched cover art (default 8MiB)                             |
-| -cover-source     | WRTAG_COVER_SOURCE     | cover-source     | Fetch cover art from the given source, "release" or "release-group", in order (stackable)            |
-| -cover-upgrade    | WRTAG_COVER_UPGRADE    | cover-upgrade    | Fetch new cover art even if it exists locally                                                        |
-| -diff-weight      | WRTAG_DIFF_WEIGHT      | diff-weight      | Adjust distance weighting for a tag (0 to ignore) (stackable)                                        |
-| -keep-file        | WRTAG_KEEP_FILE        | keep-file        | Define an extra file path to keep when moving/copying to root dir (stackable)                        |
-| -log-level        | WRTAG_LOG_LEVEL        | log-level        | Set the logging level (default INFO)                                                                 |
-| -mb-base-url      | WRTAG_MB_BASE_URL      | mb-base-url      | MusicBrainz base URL (default "<https://musicbrainz.org/ws/2/>")                                     |
-| -mb-rate-limit    | WRTAG_MB_RATE_LIMIT    | mb-rate-limit    | MusicBrainz rate limit duration (default 1s)                                                         |
-| -notification-uri | WRTAG_NOTIFICATION_URI | notification-uri | Add a shoutrrr notification URI for an event (see [Notifications](#notifications)) (stackable)       |
-| -path-format      | WRTAG_PATH_FORMAT      | path-format      | Path to root music directory including path format rules (see [Path format](#path-format))           |
-| -research-link    | WRTAG_RESEARCH_LINK    | research-link    | Define a helper URL to help find information about an unmatched release (stackable)                  |
-| -tag-config       | WRTAG_TAG_CONFIG       | tag-config       | Specify tag keep and drop rules when writing new tag revisions (see [Tagging](#tagging)) (stackable) |
-| -version          | WRTAG_VERSION          | version          | Print the version and exit                                                                           |
+| CLI argument      | Environment variable   | Config file key  | Description                                                                                                                |
+| ----------------- | ---------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| -addon            | WRTAG_ADDON            | addon            | Define an addon for extra metadata writing (see [Addons](#addons)) (stackable)                                             |
+| -caa-base-url     | WRTAG_CAA_BASE_URL     | caa-base-url     | CoverArtArchive base URL (default "<https://coverartarchive.org/>")                                                        |
+| -caa-rate-limit   | WRTAG_CAA_RATE_LIMIT   | caa-rate-limit   | CoverArtArchive rate limit duration                                                                                        |
+| -config           | WRTAG_CONFIG           | config           | Print the parsed config and exit                                                                                           |
+| -config-path      | WRTAG_CONFIG_PATH      | config-path      | Path to config file (default "$XDG_CONFIG_HOME/wrtag/config")                                                              |
+| -cover-max-size   | WRTAG_COVER_MAX_SIZE   | cover-max-size   | Maximum size in B, KiB, MiB, or GiB for fetched cover art (default 8MiB)                                                   |
+| -cover-source     | WRTAG_COVER_SOURCE     | cover-source     | Fetch cover art from the given source, "release" or "release-group", in order (stackable) (default release, release-group) |
+| -cover-upgrade    | WRTAG_COVER_UPGRADE    | cover-upgrade    | Fetch new cover art even if it exists locally                                                                              |
+| -diff-weight      | WRTAG_DIFF_WEIGHT      | diff-weight      | Adjust distance weighting for a tag (0 to ignore) (stackable)                                                              |
+| -file-mode        | WRTAG_FILE_MODE        | file-mode        | File mode for destinations files (on Unix-like systems, the default respects current umask) (default 0644)                 |
+| -keep-file        | WRTAG_KEEP_FILE        | keep-file        | Define an extra file path to keep when moving/copying to root dir (stackable)                                              |
+| -log-level        | WRTAG_LOG_LEVEL        | log-level        | Set the logging level (default INFO)                                                                                       |
+| -mb-base-url      | WRTAG_MB_BASE_URL      | mb-base-url      | MusicBrainz base URL (default "<https://musicbrainz.org/ws/2/>")                                                           |
+| -mb-rate-limit    | WRTAG_MB_RATE_LIMIT    | mb-rate-limit    | MusicBrainz rate limit duration (default 1s)                                                                               |
+| -notification-uri | WRTAG_NOTIFICATION_URI | notification-uri | Add a shoutrrr notification URI for an event (see [Notifications](#notifications)) (stackable)                             |
+| -path-format      | WRTAG_PATH_FORMAT      | path-format      | Path to root music directory including path format rules (see [Path format](#path-format))                                 |
+| -research-link    | WRTAG_RESEARCH_LINK    | research-link    | Define a helper URL to help find information about an unmatched release (stackable)                                        |
+| -tag-config       | WRTAG_TAG_CONFIG       | tag-config       | Specify tag keep and drop rules when writing new tag revisions (see [Tagging](#tagging)) (stackable)                       |
+| -version          | WRTAG_VERSION          | version          | Print the version and exit                                                                                                 |
 
 ### Format
 

--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ Global configuration is used by all tools. Any option can be provided with a CLI
 | -caa-rate-limit   | WRTAG_CAA_RATE_LIMIT   | caa-rate-limit   | CoverArtArchive rate limit duration                                                                  |
 | -config           | WRTAG_CONFIG           | config           | Print the parsed config and exit                                                                     |
 | -config-path      | WRTAG_CONFIG_PATH      | config-path      | Path to config file (default "$XDG_CONFIG_HOME/wrtag/config")                                        |
+| -cover-max-size   | WRTAG_COVER_MAX_SIZE   | cover-max-size   | Maximum size in MiB for fetched cover art (default 8 MiB)                                            |
 | -cover-source     | WRTAG_COVER_SOURCE     | cover-source     | Fetch cover art from the given source, "release" or "release-group", in order (stackable)            |
 | -cover-upgrade    | WRTAG_COVER_UPGRADE    | cover-upgrade    | Fetch new cover art even if it exists locally                                                        |
 | -diff-weight      | WRTAG_DIFF_WEIGHT      | diff-weight      | Adjust distance weighting for a tag (0 to ignore) (stackable)                                        |

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ Global configuration is used by all tools. Any option can be provided with a CLI
 | -caa-rate-limit   | WRTAG_CAA_RATE_LIMIT   | caa-rate-limit   | CoverArtArchive rate limit duration                                                                  |
 | -config           | WRTAG_CONFIG           | config           | Print the parsed config and exit                                                                     |
 | -config-path      | WRTAG_CONFIG_PATH      | config-path      | Path to config file (default "$XDG_CONFIG_HOME/wrtag/config")                                        |
-| -cover-max-size   | WRTAG_COVER_MAX_SIZE   | cover-max-size   | Maximum size in MiB for fetched cover art (default 8 MiB)                                            |
+| -cover-max-size   | WRTAG_COVER_MAX_SIZE   | cover-max-size   | Maximum size in B, KiB, MiB, or GiB for fetched cover art (default 8MiB)                             |
 | -cover-source     | WRTAG_COVER_SOURCE     | cover-source     | Fetch cover art from the given source, "release" or "release-group", in order (stackable)            |
 | -cover-upgrade    | WRTAG_COVER_UPGRADE    | cover-upgrade    | Fetch new cover art even if it exists locally                                                        |
 | -diff-weight      | WRTAG_DIFF_WEIGHT      | diff-weight      | Adjust distance weighting for a tag (0 to ignore) (stackable)                                        |

--- a/cmd/internal/wrtagflag/wrtagflag.go
+++ b/cmd/internal/wrtagflag/wrtagflag.go
@@ -102,7 +102,7 @@ func Config() *wrtag.Config {
 	flag.BoolVar(&cfg.UpgradeCover, "cover-upgrade", false, "Fetch new cover art even if it exists locally")
 
 	cfg.MaxCoverSize = 8 * 1024 * 1024
-	flag.Var(&sizeParser{&cfg.MaxCoverSize}, "cover-max-size", "Maximum size in B, KiB, MiB, or GiB for fetched cover art (default 8MiB)")
+	flag.Var(&sizeParser{&cfg.MaxCoverSize}, "cover-max-size", "Maximum size in B, KiB, MiB, or GiB for fetched cover art")
 
 	cfg.FileMode = defaultFileMode
 	flag.Var(&fileModeParser{&cfg.FileMode}, "file-mode", "File mode for destinations files (on Unix-like systems, the default respects current umask)")

--- a/cmd/internal/wrtagflag/wrtagflag.go
+++ b/cmd/internal/wrtagflag/wrtagflag.go
@@ -102,14 +102,7 @@ func Config() *wrtag.Config {
 	flag.BoolVar(&cfg.UpgradeCover, "cover-upgrade", false, "Fetch new cover art even if it exists locally")
 
 	cfg.MaxCoverSize = 8 * 1024 * 1024
-	flag.Func("cover-max-size", "Maximum size in MiB for fetched cover art (default 8 MiB)", func(s string) error {
-		mib, err := strconv.ParseInt(s, 10, 64)
-		if err != nil || mib <= 0 {
-			return fmt.Errorf("must be positive non-zero integer")
-		}
-		cfg.MaxCoverSize = mib * 1024 * 1024
-		return nil
-	})
+	flag.Var(&sizeParser{&cfg.MaxCoverSize}, "cover-max-size", "Maximum size in B, KiB, MiB, or GiB for fetched cover art (default 8MiB)")
 
 	cfg.FileMode = defaultFileMode
 	flag.Var(&fileModeParser{&cfg.FileMode}, "file-mode", "File mode for destinations files (on Unix-like systems, the default respects current umask)")
@@ -388,6 +381,41 @@ func (rl *rateLimitParser) String() string {
 		return ""
 	}
 	return dur.String()
+}
+
+type sizeParser struct{ *int64 }
+
+func (s sizeParser) Set(value string) error {
+	value = strings.TrimSpace(value)
+	for i, suffix := range sizeUnits {
+		before, found := strings.CutSuffix(value, suffix)
+		if found {
+			n, err := strconv.ParseInt(strings.TrimSpace(before), 10, 64)
+			if err != nil || n <= 0 {
+				return errors.New("number must be a positive non-zero integer")
+			}
+			*s.int64 = n * sizeUnitBytes(i)
+			return nil
+		}
+	}
+	return errors.New("no valid size unit suffixed (B, KiB, MiB, GiB)")
+}
+func (s sizeParser) String() string {
+	if s.int64 == nil {
+		return ""
+	}
+	for i, suffix := range sizeUnits {
+		if *s.int64%sizeUnitBytes(i) == 0 {
+			return strconv.FormatInt(*s.int64/sizeUnitBytes(i), 10) + suffix
+		}
+	}
+	return ""
+}
+
+var sizeUnits = [...]string{"GiB", "MiB", "KiB", "B"}
+
+func sizeUnitBytes(i int) int64 {
+	return 1 << (10 * (len(sizeUnits) - 1 - i))
 }
 
 type fileModeParser struct {

--- a/cmd/internal/wrtagflag/wrtagflag.go
+++ b/cmd/internal/wrtagflag/wrtagflag.go
@@ -101,6 +101,16 @@ func Config() *wrtag.Config {
 
 	flag.BoolVar(&cfg.UpgradeCover, "cover-upgrade", false, "Fetch new cover art even if it exists locally")
 
+	cfg.MaxCoverSize = 8 * 1024 * 1024
+	flag.Func("cover-max-size", "Maximum size in MiB for fetched cover art (default 8 MiB)", func(s string) error {
+		mib, err := strconv.ParseInt(s, 10, 64)
+		if err != nil || mib <= 0 {
+			return fmt.Errorf("must be positive non-zero integer")
+		}
+		cfg.MaxCoverSize = mib * 1024 * 1024
+		return nil
+	})
+
 	cfg.FileMode = defaultFileMode
 	flag.Var(&fileModeParser{&cfg.FileMode}, "file-mode", "File mode for destinations files (on Unix-like systems, the default respects current umask)")
 

--- a/contrib/completions/wrtag.bash
+++ b/contrib/completions/wrtag.bash
@@ -21,6 +21,7 @@ function _wrtag_completion() {
         --caa-rate-limit
         --config
         --config-path
+        --cover-max-size
         --cover-source
         --cover-upgrade
         --diff-weight
@@ -43,6 +44,7 @@ function _wrtag_completion() {
         -caa-rate-limit
         -config
         -config-path
+        -cover-max-size
         -cover-source
         -cover-upgrade
         -diff-weight

--- a/contrib/completions/wrtag.fish
+++ b/contrib/completions/wrtag.fish
@@ -42,7 +42,7 @@ __complete_prefer_oldstyle -c wrtag -n "not __fish_seen_subcommand_from $command
     -o config-path -rF -d 'Path to config file (default "/$HOME/.config/wrtag/config")'
 
 __complete_prefer_oldstyle -c wrtag -n "not __fish_seen_subcommand_from $commands" \
-    -o cover-max-size -x -d "Maximum size in MiB for fetched cover art (default 8 MiB)"
+    -o cover-max-size -x -d "Maximum size in B, KiB, MiB, or GiB for fetched cover art (default 8MiB)"
 
 __complete_prefer_oldstyle -c wrtag -n "not __fish_seen_subcommand_from $commands" \
     -o cover-source -x -a "release release-group" -d "Fetch cover art from the given source, in order"

--- a/contrib/completions/wrtag.fish
+++ b/contrib/completions/wrtag.fish
@@ -42,6 +42,9 @@ __complete_prefer_oldstyle -c wrtag -n "not __fish_seen_subcommand_from $command
     -o config-path -rF -d 'Path to config file (default "/$HOME/.config/wrtag/config")'
 
 __complete_prefer_oldstyle -c wrtag -n "not __fish_seen_subcommand_from $commands" \
+    -o cover-max-size -x -d "Maximum size in MiB for fetched cover art (default 8 MiB)"
+
+__complete_prefer_oldstyle -c wrtag -n "not __fish_seen_subcommand_from $commands" \
     -o cover-source -x -a "release release-group" -d "Fetch cover art from the given source, in order"
 
 __complete_prefer_oldstyle -c wrtag -n "not __fish_seen_subcommand_from $commands" \

--- a/wrtag.go
+++ b/wrtag.go
@@ -90,6 +90,7 @@ type Config struct {
 	Addons                []addon.Addon
 	CoverSources          []musicbrainz.CoverSource
 	UpgradeCover          bool
+	MaxCoverSize          int64
 	FileMode              os.FileMode
 }
 
@@ -222,7 +223,7 @@ func ProcessDir(
 	var coverTmp string
 	if op.CanModifyDest() && (cover == "" || cfg.UpgradeCover) {
 		var err error
-		coverTmp, err = maybeFetchUpgradedCover(ctx, &cfg.CoverArtArchiveClient, release, cfg.CoverSources, cover, maxCoverSizeBytes)
+		coverTmp, err = maybeFetchUpgradedCover(ctx, &cfg.CoverArtArchiveClient, release, cfg.CoverSources, cover, cfg.MaxCoverSize)
 		if err != nil {
 			return nil, fmt.Errorf("fetch cover: %w", err)
 		}
@@ -1022,12 +1023,10 @@ func copyFile(src, dest string) (err error) {
 	return nil
 }
 
-const maxCoverSizeBytes = 8 * 1024 * 1024 // 8 MiB
-
 func maybeFetchUpgradedCover(ctx context.Context, caa *musicbrainz.CAAClient, release *musicbrainz.Release, sources []musicbrainz.CoverSource, cover string, maxSize int64) (string, error) {
 	skipFunc := func(resp *http.Response) bool {
 		if resp.ContentLength > maxSize {
-			slog.WarnContext(ctx, "skipping downloading cover which is larger than max size", "size_bytes", resp.ContentLength, "max_size_bytes", maxCoverSizeBytes)
+			slog.WarnContext(ctx, "skipping downloading cover which is larger than max size", "size_bytes", resp.ContentLength, "max_size_bytes", maxSize)
 			return true
 		}
 		if cover == "" {


### PR DESCRIPTION
I found that when fetching cover arts, the sizes of the images sometimes exceed a hard-coded maximum file size, when I'd otherwise prefer to keep the images. I'm sure there could also be a scenario where one would on the other hand want a lower maximum file size to save space or speed up loading said cover arts.

Here, I added a relatively simple option that accepts a valid size in MiB to serve as the maximum cover art image size, though I'd like to hear if you think a better way of doing this should be implemented, like maybe allowing for different binary prefixes such as KiB as well, something more complex involving the resolution of an image (and at that point, perhaps automatic resizing with external tools, like in other programs?), or just sticking with a hard-coded limit. I feel like in this case it's a matter of being more extensible in a sense versus retaining simplicity. Thanks